### PR TITLE
Initialize vuex store and redirect to inspector page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1172,6 +1172,12 @@
         "xtend": "~4.0.0"
       }
     },
+    "accessibility-developer-tools": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/accessibility-developer-tools/-/accessibility-developer-tools-2.12.0.tgz",
+      "integrity": "sha1-PaDM6dbsY3OWS4TzXbfPw996tRQ=",
+      "dev": true
+    },
     "acorn": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.0.tgz",
@@ -2349,6 +2355,17 @@
       "integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==",
       "dev": true,
       "optional": true
+    },
+    "devtron": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/devtron/-/devtron-1.4.0.tgz",
+      "integrity": "sha1-tedIvW6Vu+cL/MaKrm/mlhGUQeE=",
+      "dev": true,
+      "requires": {
+        "accessibility-developer-tools": "^2.11.0",
+        "highlight.js": "^9.3.0",
+        "humanize-plus": "^1.8.1"
+      }
     },
     "diffie-hellman": {
       "version": "5.0.3",
@@ -3887,6 +3904,12 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
+    "highlight.js": {
+      "version": "9.18.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.18.1.tgz",
+      "integrity": "sha512-OrVKYz70LHsnCgmbXctv/bfuvntIKDz177h0Co37DQ5jamGZLVmoCVMtjMtNZY3X9DrCcKfklHPNeA0uPZhSJg==",
+      "dev": true
+    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -4026,6 +4049,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
       "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
+      "dev": true
+    },
+    "humanize-plus": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/humanize-plus/-/humanize-plus-1.8.2.tgz",
+      "integrity": "sha1-pls0RZrWNnrbs3B6gqPJ+RYWcDA=",
       "dev": true
     },
     "husky": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@babel/preset-env": "7.8.4",
     "babel-loader": "8.0.6",
     "css-loader": "3.4.2",
+    "devtron": "1.4.0",
     "electron": "8.0.1",
     "file-loader": "5.1.0",
     "html-webpack-plugin": "3.2.0",

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -3,20 +3,21 @@
     <header>
       <div class="logo"></div>
     </header>
-    <form>
+    <form @submit.prevent="connect">
       <p>Select path to LevelDB</p>
       <label class="file db-path">
         <input type="text" id="file" webkitdirectory />
         <span class="file-custom" @click="selectPath">{{ path }}</span>
       </label>
-      <button @click="connect">Inspect</button>
+      <button>Inspect</button>
     </form>
     <footer>Copyright {{ new Date().getFullYear() }} • UncaughtException</footer>
   </main>
 </template>
 
 <script>
-import { ipcRenderer, remote } from 'electron';
+import { remote } from 'electron';
+import { mapActions } from 'vuex';
 
 export default {
   data() {
@@ -24,29 +25,15 @@ export default {
       path: ''
     };
   },
-  methods: {
-    connect(e) {
-      e.preventDefault();
-      const response = ipcRenderer.sendSync('leveldb-command', {
-        command: 'connect',
-        params: {
-          path: this.path,
-          createIfMissing: false,
-          valueEncoding: 'text'
-        }
-      });
 
-      if (response.status === 'success') {
-        // TODO: this should open the next page
-        alert('success');
-      } else {
-        // TODO: We need a place to display this error message
-        alert(
-          response.message ||
-            'Failed to open the database. Please make sure the database exists or is not opened by another process.'
-        );
-      }
+  methods: {
+    ...mapActions(['connectToDatabase']),
+
+    async connect() {
+      const success = await this.connectToDatabase(this.path);
+      console.log(success);
     },
+
     selectPath(e) {
       const path = remote.dialog.showOpenDialog({
         properties: ['openDirectory']

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -30,8 +30,12 @@ export default {
     ...mapActions(['connectToDatabase']),
 
     async connect() {
-      const success = await this.connectToDatabase(this.path);
-      console.log(success);
+      const { error } = await this.connectToDatabase(this.path);
+      if (error) {
+        alert(error);
+      } else {
+        this.$router.push('/inspector');
+      }
     },
 
     selectPath(e) {

--- a/src/renderer-process.js
+++ b/src/renderer-process.js
@@ -1,9 +1,11 @@
 import Vue from 'vue';
 import router from './router';
+import store from './store';
 import App from '@components/App.vue';
 
 new Vue({
   el: '#app',
   router,
+  store,
   render: h => h(App)
 });

--- a/src/store.js
+++ b/src/store.js
@@ -1,0 +1,16 @@
+import Vue from 'vue';
+import Vuex from 'vuex';
+
+Vue.use(Vuex);
+
+const state = {};
+
+const mutations = {};
+
+const actions = {};
+
+export default new Vuex.Store({
+  state,
+  mutations,
+  actions
+});

--- a/src/store.js
+++ b/src/store.js
@@ -1,13 +1,37 @@
 import Vue from 'vue';
 import Vuex from 'vuex';
+import { ipcRenderer } from 'electron';
 
 Vue.use(Vuex);
 
-const state = {};
+const state = {
+  path: null
+};
 
-const mutations = {};
+const mutations = {
+  setPath(state, path) {
+    state.path = path;
+  }
+};
 
-const actions = {};
+const actions = {
+  connectToDatabase({ commit }, path) {
+    const response = ipcRenderer.sendSync('leveldb-command', {
+      command: 'connect',
+      params: {
+        path,
+        createIfMissing: false,
+        valueEncoding: 'text'
+      }
+    });
+
+    if (response.status === 'success') {
+      commit('setPath', path);
+      return true;
+    }
+    return false;
+  }
+};
 
 export default new Vuex.Store({
   state,

--- a/src/store.js
+++ b/src/store.js
@@ -16,7 +16,7 @@ const mutations = {
 
 const actions = {
   connectToDatabase({ commit }, path) {
-    const response = ipcRenderer.sendSync('leveldb-command', {
+    const { status, message } = ipcRenderer.sendSync('leveldb-command', {
       command: 'connect',
       params: {
         path,
@@ -25,11 +25,11 @@ const actions = {
       }
     });
 
-    if (response.status === 'success') {
-      commit('setPath', path);
-      return true;
+    if (status === 'failed') {
+      return { success: false, error: message };
     }
-    return false;
+    commit('setPath', path);
+    return { success: true };
   }
 };
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,7 +12,15 @@ const commonRules = [
     loader: 'babel-loader',
     exclude: /node_modules/,
     options: {
-      presets: ['@babel/preset-env']
+      presets: [
+        [
+          '@babel/preset-env',
+          {
+            useBuiltIns: 'usage',
+            corejs: 3
+          }
+        ]
+      ]
     }
   }
 ];


### PR DESCRIPTION
**Changelog**

- Initialize new Vuex store instance
- Move logic for connecting into the database from `Home.vue` into a Vuex action called `connectToDatabase`
- After successful connection, redirect the app to the inspector page
- Add [devtron](https://www.electronjs.org/devtron) for debugging the Electron app (e.g. IPC messages). Run enable by running `require('devtron').install()` in the DevTools console.